### PR TITLE
[server] adds db migration scripts and such

### DIFF
--- a/server/apolloServer.js
+++ b/server/apolloServer.js
@@ -1,12 +1,16 @@
 const { ApolloServer } = require('apollo-server-express');
-const { getUser } = require('./services/tokenService');
+const { parseToken } = require('./services/tokenService');
 const typeDefs = require('./schema/typeDefs');
 const resolvers = require('./schema/resolvers');
 
-const context = req => {
+const context = ({ req }) => {
   const token = (req.headers && req.headers.authorization) || '';
-  const user = getUser(token);
-  return { user };
+  try {
+    const parsedToken = parseToken(token.substring(7));
+    return { user: parsedToken };
+  } catch {
+    return {};
+  }
 };
 
 module.exports = new ApolloServer({ typeDefs, resolvers, context });

--- a/server/config/database.json
+++ b/server/config/database.json
@@ -1,0 +1,10 @@
+{
+  "dev": {
+    "driver": "pg",
+    "user": { "ENV": "PGUSER" },
+    "password": { "ENV": "PGPASSWORD" },
+    "host": { "ENV": "PGHOST" },
+    "database": { "ENV": "PGDATABASE" },
+    "port": { "ENV": "PGPORT" }
+  }
+}

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -1,9 +1,9 @@
-require("dotenv").config();
-const passport = require("passport");
-const GoogleStrategy = require("passport-google-oauth").OAuth2Strategy;
-const FacebookStrategy = require("passport-facebook").Strategy;
+require('dotenv').config();
+const passport = require('passport');
+const GoogleStrategy = require('passport-google-oauth').OAuth2Strategy;
+const FacebookStrategy = require('passport-facebook').Strategy;
 // const TwitterStrategy = require("passport-twitter").Strategy;
-const userRepository = require("../repositories/UserRepository");
+const userRepository = require('../repositories/UserRepository');
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
@@ -15,14 +15,19 @@ const FACEBOOK_APP_SECRET = process.env.FACEBOOK_APP_SECRET;
 module.exports = function configPassport(app) {
   app.use(passport.initialize());
 
-  const handleAuthentication = (accessToken, refreshToken, profile, done) => {
+  const handleAuthentication = async (
+    accessToken,
+    refreshToken,
+    profile,
+    done
+  ) => {
     try {
-      let user = userRepository.getUserByProviderId(
+      let user = await userRepository.getUserByProviderId(
         profile.provider,
         profile.id
       );
       if (!user) {
-        user = userRepository.createUser(
+        user = await userRepository.createUser(
           profile.provider,
           profile.id,
           profile.displayName
@@ -38,7 +43,7 @@ module.exports = function configPassport(app) {
     new GoogleStrategy(
       {
         clientID: GOOGLE_CLIENT_ID,
-        clientSecret: GOOGLE_CLIENT_SECRET
+        clientSecret: GOOGLE_CLIENT_SECRET,
       },
       handleAuthentication
     )
@@ -48,7 +53,7 @@ module.exports = function configPassport(app) {
     new FacebookStrategy(
       {
         clientID: FACEBOOK_APP_ID,
-        clientSecret: FACEBOOK_APP_SECRET
+        clientSecret: FACEBOOK_APP_SECRET,
       },
       handleAuthentication
     )

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -1,0 +1,9 @@
+const { Pool } = require('pg');
+
+const pool = new Pool();
+
+module.exports = {
+  query: async (text, params) => {
+    return await pool.query(text, params);
+  },
+};

--- a/server/db/migrations/20190516021145-add-users.js
+++ b/server/db/migrations/20190516021145-add-users.js
@@ -20,9 +20,18 @@ exports.up = function(db) {
       type: 'serial',
       primaryKey: true,
     },
-    username: 'string',
-    provider: 'string',
-    providerid: 'string',
+    username: {
+      type: 'string',
+      notNull: true,
+    },
+    provider: {
+      type: 'string',
+      notNull: true,
+    },
+    providerid: {
+      type: 'string',
+      notNull: true,
+    },
   });
 };
 

--- a/server/db/migrations/20190516021145-add-users.js
+++ b/server/db/migrations/20190516021145-add-users.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  return db.createTable('users', {
+    id: {
+      type: 'serial',
+      primaryKey: true,
+    },
+    username: 'string',
+    provider: 'string',
+    providerid: 'string',
+  });
+};
+
+exports.down = function(db) {
+  return db.dropTable('users');
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -498,6 +498,15 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -508,6 +517,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
       "dev": true
     },
     "async-each": {
@@ -627,6 +642,12 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "bluebird": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+      "dev": true
+    },
     "body-parser": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
@@ -718,6 +739,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "busboy": {
       "version": "0.3.1",
@@ -904,6 +930,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
@@ -1017,6 +1049,71 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true
+    },
+    "db-migrate": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/db-migrate/-/db-migrate-0.11.5.tgz",
+      "integrity": "sha512-2HSBOQBaKwq93OpMfdBR9O9gm3eTRgj4HB+Zzy7/YJxxNuxGKY9JDCe/Mb0QRlYqxVQDFUJCJRZcDVxadAUDgg==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "bluebird": "^3.1.1",
+        "db-migrate-shared": "^1.2.0",
+        "deep-extend": "^0.6.0",
+        "dotenv": "^5.0.1",
+        "final-fs": "^1.6.0",
+        "inflection": "^1.10.0",
+        "mkdirp": "~0.5.0",
+        "optimist": "~0.6.1",
+        "parse-database-url": "~0.3.0",
+        "pkginfo": "^0.4.0",
+        "prompt": "^1.0.0",
+        "rc": "^1.2.8",
+        "resolve": "^1.1.6",
+        "semver": "^5.3.0",
+        "tunnel-ssh": "^4.0.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
+          "dev": true
+        }
+      }
+    },
+    "db-migrate-base": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/db-migrate-base/-/db-migrate-base-1.6.3.tgz",
+      "integrity": "sha512-O6Kh72Yh0DfvRAKg9QKzu1KkMwI5iI0dFHO6RmDLvbiYvtRW3faFXJNFwJYeioVBx22QA3AkVFbDIcw4j4QxGw==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.1.1"
+      }
+    },
+    "db-migrate-pg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/db-migrate-pg/-/db-migrate-pg-0.5.1.tgz",
+      "integrity": "sha512-vbWE4uEjvddENHYgghomTcFAU/JW7sO+U7EYgNZWDl64f64KYtF2oqUr8iKHXKvCPGzhbub+88lV0s7ZCdJ8nA==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.1.1",
+        "db-migrate-base": "^1.6.3",
+        "pg": "^7.8.0",
+        "semver": "^5.0.3"
+      }
+    },
+    "db-migrate-shared": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/db-migrate-shared/-/db-migrate-shared-1.2.0.tgz",
+      "integrity": "sha512-65k86bVeHaMxb2L0Gw3y5V+CgZSRwhVQMwDMydmw5MvIpHHwD6SmBciqIwHsZfzJ9yzV/yYhdRefRM6FV5/siw==",
+      "dev": true
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -1054,6 +1151,12 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
+    },
+    "deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -1446,6 +1549,12 @@
         }
       }
     },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -1472,6 +1581,16 @@
             "is-extendable": "^0.1.0"
           }
         }
+      }
+    },
+    "final-fs": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/final-fs/-/final-fs-1.6.1.tgz",
+      "integrity": "sha1-1tzZLvb+T+jAer1WjHE1YQ7eMjY=",
+      "dev": true,
+      "requires": {
+        "node-fs": "~0.1.5",
+        "when": "~2.0.1"
       }
     },
     "finalhandler": {
@@ -1597,8 +1716,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1619,14 +1737,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1641,20 +1757,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1771,8 +1884,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1784,7 +1896,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1799,7 +1910,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1807,14 +1917,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1833,7 +1941,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1914,8 +2021,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1927,7 +2033,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2013,8 +2118,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2050,7 +2154,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2070,7 +2173,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2114,14 +2216,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2378,6 +2478,12 @@
         "statuses": ">= 1.4.0 < 2"
       }
     },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
@@ -2402,6 +2508,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflection": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
       "dev": true
     },
     "inflight": {
@@ -2689,6 +2801,12 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
     "iterall": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
@@ -2785,6 +2903,12 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
       "dev": true
     },
     "lodash.includes": {
@@ -3062,6 +3186,12 @@
         }
       }
     },
+    "mongodb-uri": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz",
+      "integrity": "sha1-D3ca0W9IOuZfQoeWlCjp+8SqYYE=",
+      "dev": true
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
@@ -3091,6 +3221,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
     "nan": {
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
@@ -3117,6 +3253,12 @@
         "to-regex": "^3.0.1"
       }
     },
+    "ncp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -3142,6 +3284,12 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
       "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw=="
+    },
+    "node-fs": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/node-fs/-/node-fs-0.1.7.tgz",
+      "integrity": "sha1-MjI8zLRsn78PwRgS1FAhzDHTJbs=",
+      "dev": true
     },
     "nodemon": {
       "version": "1.18.11",
@@ -3304,6 +3452,24 @@
         "wrappy": "1"
       }
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        }
+      }
+    },
     "os-locale": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
@@ -3406,6 +3572,20 @@
         "registry-auth-token": "^3.0.1",
         "registry-url": "^3.0.3",
         "semver": "^5.1.0"
+      }
+    },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
+    "parse-database-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/parse-database-url/-/parse-database-url-0.3.0.tgz",
+      "integrity": "sha1-NpZmMh6SfJreY838Gqr2+zdFPQ0=",
+      "dev": true,
+      "requires": {
+        "mongodb-uri": ">= 0.9.7"
       }
     },
     "parseurl": {
@@ -3535,6 +3715,12 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -3551,10 +3737,72 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
+    "pg": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.11.0.tgz",
+      "integrity": "sha512-YO4V7vCmEMGoF390LJaFaohWNKaA2ayoQOEZmiHVcAUF+YsRThpf/TaKCgSvsSE7cDm37Q/Cy3Gz41xiX/XjTw==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "0.1.3",
+        "pg-pool": "^2.0.4",
+        "pg-types": "~2.0.0",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+        }
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.6.tgz",
+      "integrity": "sha512-hod2zYQxM8Gt482q+qONGTYcg/qVcV32VHVPtktbBJs0us3Dj7xibISw0BAAXVMCzt8A/jhfJvpZaxUlqtqs0g=="
+    },
+    "pg-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.0.1.tgz",
+      "integrity": "sha512-b7y6QM1VF5nOeX9ukMQ0h8a9z89mojrBHXfJeSug4mhL0YpxNBm83ot2TROyoAmX/ZOX3UbwVO4EbH7i1ZZNiw==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "requires": {
+        "split": "^1.0.0"
+      }
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
       "dev": true
     },
     "posix-character-classes": {
@@ -3562,6 +3810,29 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+    },
+    "postgres-date": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
+      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -3574,6 +3845,20 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
+    },
+    "prompt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
+      "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "pkginfo": "0.x.x",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "utile": "0.3.x",
+        "winston": "2.1.x"
+      }
     },
     "protobufjs": {
       "version": "6.8.8",
@@ -3666,6 +3951,15 @@
         "strip-json-comments": "~2.0.1"
       }
     },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -3751,6 +4045,15 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "resolve": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -3767,6 +4070,21 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -4047,6 +4365,14 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4060,6 +4386,32 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "ssh2": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.5.4.tgz",
+      "integrity": "sha1-G/a2soyW6u8mf01sRqWiUXpZnic=",
+      "dev": true,
+      "requires": {
+        "ssh2-streams": "~0.1.15"
+      }
+    },
+    "ssh2-streams": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.1.20.tgz",
+      "integrity": "sha1-URGNFUVV31Rp7h9n4M8efoosDjo=",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.0",
+        "semver": "^5.1.0",
+        "streamsearch": "~0.1.2"
+      }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
     "static-extend": {
@@ -4196,6 +4548,11 @@
         "execa": "^0.7.0"
       }
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
@@ -4270,6 +4627,28 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
+    "tunnel-ssh": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tunnel-ssh/-/tunnel-ssh-4.1.4.tgz",
+      "integrity": "sha512-CjBqboGvAbM7iXSX2F95kzoI+c2J81YkrHbyyo4SWNKCzU6w5LfEvXBCHu6PPriYaNvfhMKzD8bFf5Vl14YTtg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "lodash.defaults": "^4.1.0",
+        "ssh2": "0.5.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "type-detect": {
       "version": "4.0.8",
@@ -4466,6 +4845,20 @@
         "object.getownpropertydescriptors": "^2.0.3"
       }
     },
+    "utile": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
+      "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+      "dev": true,
+      "requires": {
+        "async": "~0.9.0",
+        "deep-equal": "~0.2.1",
+        "i": "0.3.x",
+        "mkdirp": "0.x.x",
+        "ncp": "1.0.x",
+        "rimraf": "2.x.x"
+      }
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -4480,6 +4873,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "when": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/when/-/when-2.0.1.tgz",
+      "integrity": "sha1-jYcv4V5oQkyRtLck6EjggH2rZkI=",
+      "dev": true
     },
     "which": {
       "version": "1.3.1",
@@ -4513,6 +4912,47 @@
       "requires": {
         "string-width": "^2.1.1"
       }
+    },
+    "winston": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+      "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+      "dev": true,
+      "requires": {
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "pkginfo": "0.3.x",
+        "stack-trace": "0.0.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
+        "pkginfo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+          "dev": true
+        }
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -4596,6 +5036,11 @@
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "xtraverse": {
       "version": "0.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "mocha -u tdd",
-    "create-migration": "node node_modules/db-migrate/bin/db-migrate create -m ./db/migrations",
+    "create-migration": "node node_modules/db-migrate/bin/db-migrate create -m ./db/migrations --config ./config/database.json",
     "migrate-up": "node node_modules/db-migrate/bin/db-migrate up -m ./db/migrations --config ./config/database.json",
     "migrate-down": "node node_modules/db-migrate/bin/db-migrate down -m ./db/migrations --config ./config/database.json"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -6,13 +6,18 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "mocha -u tdd"
+    "test": "mocha -u tdd",
+    "create-migration": "node node_modules/db-migrate/bin/db-migrate create -m ./db/migrations",
+    "migrate-up": "node node_modules/db-migrate/bin/db-migrate up -m ./db/migrations --config ./config/database.json",
+    "migrate-down": "node node_modules/db-migrate/bin/db-migrate down -m ./db/migrations --config ./config/database.json"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
+    "db-migrate": "^0.11.5",
+    "db-migrate-pg": "^0.5.1",
     "mocha": "^6.1.4",
     "morgan": "^1.9.1",
     "nodemon": "^1.18.11"
@@ -29,6 +34,7 @@
     "passport-facebook": "^3.0.0",
     "passport-google-oauth": "^2.0.0",
     "passport-local": "^1.0.0",
-    "passport-twitter": "^1.0.4"
+    "passport-twitter": "^1.0.4",
+    "pg": "^7.11.0"
   }
 }

--- a/server/repositories/UserRepository.js
+++ b/server/repositories/UserRepository.js
@@ -26,7 +26,6 @@ class UserRepository {
       );
       return res.rows[0];
     } catch (err) {
-      console.log('me');
       console.log(err.stack);
     }
   }

--- a/server/repositories/UserRepository.js
+++ b/server/repositories/UserRepository.js
@@ -1,35 +1,87 @@
-const mockUsers = require("../mock_data/mockUsers");
+const db = require('../db');
+const mockUsers = require('../mock_data/mockUsers');
 
-const users = [];
+// const users = [];
 
 class UserRepository {
-  static getUserByProviderId(provider, providerId) {
-    return users.find(
-      u => u.provider === provider && u.providerId === providerId
-    );
+  static async getUserByProviderId(provider, providerId) {
+    // return users.find(
+    //   u => u.provider === provider && u.providerId === providerId
+    // );
+
+    try {
+      const res = await db.query(
+        `
+        SELECT
+          id
+          ,username
+          ,provider
+          ,providerid
+        FROM users
+        WHERE 
+          provider = $1
+          AND providerid = $2
+      `,
+        [provider, providerId]
+      );
+      return res.rows[0];
+    } catch (err) {
+      console.log('me');
+      console.log(err.stack);
+    }
   }
 
-  static createUser(provider, providerId, displayName) {
-    const user = {
-      id: "some id",
-      displayName,
-      provider,
-      providerId
-    };
-    users.push(user);
-    return user;
-  }
-
-  static getUsers() {
-    return mockUsers;
+  static async createUser(provider, providerId, displayName) {
+    // const user = {
+    //   id: 'some id',
+    //   displayName,
+    //   provider,
+    //   providerId,
+    // };
+    // users.push(user);
+    try {
+      const res = await db.query(
+        `
+        INSERT INTO users(username, provider, providerid)
+        VALUES($1, $2, $3)
+        RETURNING
+          id
+          ,username
+          ,provider
+          ,providerid
+      `,
+        [displayName, provider, providerId]
+      );
+      return res.rows[0];
+    } catch (err) {
+      console.log(err.stack);
+    }
   }
 
   static getUsersByIds(ids) {
     return mockUsers.filter(u => ids.indexOf(u.id.toString()) >= 0);
   }
 
-  static getUser(id) {
-    return mockUsers.filter(u => u.id.toString() === "1");
+  static async getUser(id) {
+    // return mockUsers.filter(u => u.id.toString() === id.toString());
+    try {
+      const res = await db.query(
+        `
+        SELECT
+          id
+          ,username
+          ,provider
+          ,providerid
+        FROM users
+        WHERE 
+          id = $1
+      `,
+        [id]
+      );
+      return res.rows[0];
+    } catch (err) {
+      console.log(err.stack);
+    }
   }
 }
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,79 +1,79 @@
-const jwt = require("jsonwebtoken");
-const express = require("express");
+const { generateToken } = require('../services/tokenService');
+const express = require('express');
 const router = express.Router();
 
 const readerTokenRedirect = (req, res) => {
-  const token = jwt.sign(req.user, "reader_secret");
+  const token = generateToken(req.user);
   res.redirect(`${process.env.READER_URL}/authredirect/${token}`);
 };
 
 const editorTokenRedirect = (req, res) => {
-  const token = jwt.sign(req.user, "editor_secret");
+  const token = generateToken(req.user);
   res.redirect(`${process.env.EDITOR_URL}/authredirect/${token}`);
 };
 
 module.exports = function authRouter(passport) {
   router.get(
-    "/reader/google",
-    passport.authenticate("google", {
-      callbackURL: "http://localhost:3002/auth/reader/google/redirect",
-      scope: ["profile"]
+    '/reader/google',
+    passport.authenticate('google', {
+      callbackURL: 'http://localhost:3002/auth/reader/google/redirect',
+      scope: ['profile'],
     })
   );
 
   router.get(
-    "/reader/google/redirect",
-    passport.authenticate("google", {
-      callbackURL: "http://localhost:3002/auth/reader/google/redirect",
-      session: false
+    '/reader/google/redirect',
+    passport.authenticate('google', {
+      callbackURL: 'http://localhost:3002/auth/reader/google/redirect',
+      session: false,
     }),
     readerTokenRedirect
   );
 
   router.get(
-    "/editor/google",
-    passport.authenticate("google", {
-      callbackURL: "http://localhost:3002/auth/editor/google/redirect",
-      scope: ["profile"]
+    '/editor/google',
+    passport.authenticate('google', {
+      callbackURL: 'http://localhost:3002/auth/editor/google/redirect',
+      scope: ['profile'],
     })
   );
 
   router.get(
-    "/editor/google/redirect",
-    passport.authenticate("google", {
-      callbackURL: "http://localhost:3002/auth/editor/google/redirect",
-      session: false
+    '/editor/google/redirect',
+    passport.authenticate('google', {
+      callbackURL: 'http://localhost:3002/auth/editor/google/redirect',
+      session: false,
     }),
     editorTokenRedirect
   );
 
   router.get(
-    "/reader/facebook",
-    passport.authenticate("facebook", {
-      callbackURL: "http://localhost:3002/auth/reader/facebook/redirect"
+    '/reader/facebook',
+    passport.authenticate('facebook', {
+      callbackURL: 'http://localhost:3002/auth/reader/facebook/redirect',
     })
   );
 
   router.get(
-    "/reader/facebook/redirect",
-    passport.authenticate("facebook", {
-      session: false
+    '/reader/facebook/redirect',
+    passport.authenticate('facebook', {
+      session: false,
     }),
     readerTokenRedirect
   );
 
   router.get(
-    "/editor/facebook",
-    passport.authenticate("facebook", {
-      callbackURL: "http://localhost:3002/auth/editor/facebook/redirect"
+    '/editor/facebook',
+    passport.authenticate('facebook', {
+      callbackURL: 'http://localhost:3002/auth/editor/facebook/redirect',
     })
   );
 
   router.get(
-    "/editor/facebook/redirect",
-    passport.authenticate("facebook", {
+    '/editor/facebook/redirect',
+    passport.authenticate('facebook', {
       session: false,
-      callbackURL: "http://localhost:3002/auth/editor/facebook/redirect"
+      callbackURL: 'http://localhost:3002/auth/editor/facebook/redirect',
     }),
     editorTokenRedirect
   );

--- a/server/server.js
+++ b/server/server.js
@@ -1,29 +1,29 @@
-require("dotenv").config();
+require('dotenv').config();
 const port = process.env.PORT || 3002;
 
-const express = require("express");
-const cors = require("cors");
+const express = require('express');
+const cors = require('cors');
 
 const app = express();
-const configPassport = require("./config/passport");
-const adventuresRouter = require("./routes/adventures");
-const draftsRouter = require("./routes/drafts");
-const authRouter = require("./routes/auth");
+const configPassport = require('./config/passport');
+const adventuresRouter = require('./routes/adventures');
+const draftsRouter = require('./routes/drafts');
+const authRouter = require('./routes/auth');
 
-if (process.env.NODE_ENV !== "production") {
-  const logger = require("morgan");
-  app.use(logger("dev"));
+if (process.env.NODE_ENV !== 'production') {
+  const logger = require('morgan');
+  app.use(logger('dev'));
 }
 app.use(cors());
 app.use(express.json());
 const passport = configPassport(app);
 
-const apolloServer = require("./apolloServer");
+const apolloServer = require('./apolloServer');
 apolloServer.applyMiddleware({ app });
 
-app.use("/auth", authRouter(passport));
-app.use("/adventures", adventuresRouter);
-app.use("/drafts", draftsRouter);
+app.use('/auth', authRouter(passport));
+app.use('/adventures', adventuresRouter);
+app.use('/drafts', draftsRouter);
 
 app.listen(port, () => {
   console.log(

--- a/server/services/tokenService.js
+++ b/server/services/tokenService.js
@@ -1,5 +1,10 @@
-const UserRepository = require('../repositories/UserRepository');
+const jwt = require('jsonwebtoken');
 
 module.exports = {
-  getUser: token => UserRepository.getUser(),
+  parseToken: token => {
+    return jwt.verify(token, process.env.TOKEN_SECRET);
+  },
+  generateToken: payload => {
+    return jwt.sign(payload, process.env.TOKEN_SECRET);
+  },
 };


### PR DESCRIPTION
So.. in this PR:
- fixes bug in apolloServer.js which wasn’t properly parsing the request for the auth token
- changes apolloServer.js to simply pull user info from token instead of using the token info to get user from repository 
- adds database.json (db-migrate config) which requires .env to contain:
  - PGUSER (username for your Postgres server). Default Postgres username is “postgres”
  - PGPASSWORD (password for your Postgres user)
  - PGHOST (address of your Postgres server). Likely “localhost”
  - PGDATABASE (name of an existing database on your Postgres server). Default Postgres db name is “postgres”
  - PGPORT (port number your Postgres server is listening to). Default Postgres port is 5432. 
- Updates passport.js to use the new async functions on UserRepository
- Adds db/index.js which wraps pg’s Pool.query (recommended by pg docs)
- Adds a migration script to add a users table to the db
- Adds packages to package.json
- Adds scripts to package.json
  - `create-migration` is used to add a migration script via db-migrate. Use like `npm run create-migration — <description-of-change>`
  - `migrate-up` and `migrate-down` will execute the migrations.
- Replaces some UserRepository functions with actual db queries
- Refactors route/auth.js to use new wrapper for generating auth tokens
- tokenService is updated to be a wrapper for jwt related stuff. 