### PR TITLE
Adding the ability to run the server from a Docker container.

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -17,6 +17,22 @@
 
 _[Return to top](#Running-CYOAB-Locally)_
 
+## Set up using 🐳 Docker
+The Docker container contains all of the necessary dependencies to run the
+backend server including, PostgreSQL and Node. This means you don't have to have
+them installed locally! It also makes it easy to move our backend server to a 
+hosting platform.
+
+1. Install [Docker](https://docs.docker.com/)
+
+2. Run `docker-compose build` from the `/server` directory.
+    - This will create the docker images on your machine
+
+3. Run `docker-compose up` to start the server
+    - From now on this is the only command you will need to run to start the server
+
+Check out the `Dockerfile` and `docker-compose.yml` to see how this is set up.
+
 ## Setting up your local machine
 
 - Be sure you have installed [Git](https://git-scm.com/downloads), [Node](https://nodejs.org/en/) 10.x, and [PostgreSQL](https://www.postgresql.org/download/) 11

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,30 @@
+# The base package for this will be the long-term-support node release
+# running on alpine linux (very lightweight)
+FROM node:lts-alpine
+
+# Expose the ports we will need
+# 3002 - The port we run the server on.
+# 9229 - The default port for node inspector
+EXPOSE 3002 9229
+
+# Set the working directory where all RUN commands will be run from
+WORKDIR /app
+
+# Copy over our package.json and package-lock so we can run an npm install
+COPY package.json /app
+COPY package-lock.json /app
+
+# We use npm ci instead of npm i. This is the prefered method when running on CI
+# as it is a "clean slate" install
+RUN npm ci
+
+# Copy the rest of our files over
+COPY . /app
+
+# Wait for postgres to start
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.2.1/wait /wait
+RUN chmod +x /wait
+
+# Start things up
+CMD /wait && npm run db-init && npm run dev
+

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,6 +2,9 @@
 # running on alpine linux (very lightweight)
 FROM node:lts-alpine
 
+RUN apk update && \
+  apk add postgresql-client
+
 # Expose the ports we will need
 # 3002 - The port we run the server on.
 # 9229 - The default port for node inspector
@@ -22,9 +25,10 @@ RUN npm ci
 COPY . /app
 
 # Wait for postgres to start
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.2.1/wait /wait
-RUN chmod +x /wait
+# ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.2.1/wait /wait
+# RUN chmod +x /wait
 
 # Start things up
-CMD /wait && npm run db-init && npm run dev
+ENTRYPOINT ["sh", "/app/docker-entrypoint.sh"]
+# CMD /wait && npm run db-init && npm run dev
 

--- a/server/config/create-database.json
+++ b/server/config/create-database.json
@@ -1,0 +1,17 @@
+{
+  "dev": {
+    "driver": "pg",
+    "user": {
+      "ENV": "PGUSER"
+    },
+    "password": {
+      "ENV": "PGPASSWORD"
+    },
+    "host": {
+      "ENV": "PGHOST"
+    },
+    "port": {
+      "ENV": "PGPORT"
+    }
+  }
+}

--- a/server/config/database.json
+++ b/server/config/database.json
@@ -1,10 +1,20 @@
 {
   "dev": {
     "driver": "pg",
-    "user": { "ENV": "PGUSER" },
-    "password": { "ENV": "PGPASSWORD" },
-    "host": { "ENV": "PGHOST" },
-    "database": { "ENV": "PGDATABASE" },
-    "port": { "ENV": "PGPORT" }
+    "user": {
+      "ENV": "PGUSER"
+    },
+    "password": {
+      "ENV": "PGPASSWORD"
+    },
+    "host": {
+      "ENV": "PGHOST"
+    },
+    "database": {
+      "ENV": "PGDATABASE"
+    },
+    "port": {
+      "ENV": "PGPORT"
+    }
   }
 }

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3"
+services:
+  app:
+    build: .
+    env_file: .env
+    depends_on:
+      - db
+    environment:
+      - WAIT_HOSTS=db:${PGPORT}
+      - PGHOST=db
+    ports:
+      - "${PORT}:${PORT}"
+      - "9229:9229"
+    # services.app.volumes entries. - .:/app/
+    # syncs the local directory to /app which is the
+    # WORKDIR defined in the Dockerfile. - /app/node_modules
+    # makes sure that the local node_modules directory
+    # (outside of Docker) doesn’t get sync-ed to the container.
+    # It’s there as an exception to the .:/app/ volume mount.
+    volumes:
+      - .:/app/
+      - /app/node_modules
+
+  db:
+    image: postgres:alpine
+    env_file: .env
+    environment:
+      - POSTGRES_DB=${PGDATABASE}
+      - POSTGRES_USER=${PGUSER}
+      - POSTGRES_PASSWORD=${PGPASSWORD}
+      - PGDATA=/var/lib/postgresql/data/pgdata
+      # Set a path where Postgres should store the data
+    restart: always
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Docker entrypoint script
+
+# Wait until Postgres is ready
+while ! pg_isready -q -h $PGHOST -p $PGPORT -U $PGUSER
+do
+  echo "$(date) - waiting for database to start"
+  sleep 2
+done
+
+# Create, migrate, and seed database if it doesn't exist.
+if [[ -z `psql -Atqc "\\list $PGDATABASE"` ]]; then
+  echo "Database $PGDATABASE does not exist. Creating..."
+  npm run db-init
+  echo "Database $PGDATABASE created."
+fi
+echo "Starting dev server on port: $PORT"
+npm run dev

--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,8 @@
     "create-migration": "node node_modules/db-migrate/bin/db-migrate create -m ./db/migrations --config ./config/database.json",
     "migrate-up": "node node_modules/db-migrate/bin/db-migrate up -m ./db/migrations --config ./config/database.json",
     "migrate-down": "node node_modules/db-migrate/bin/db-migrate down -m ./db/migrations --config ./config/database.json",
-    "seed": "node -r dotenv/config db/seed.js"
+    "seed": "node -r dotenv/config db/seed.js",
+    "db-init": "node node_modules/db-migrate/bin/db-migrate db:create cyoab --config ./config/create-database.json "
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Added the ability to run the server from a 🐳 Docker container!

This will help when we want to host this somewhere else, or run it on a service like Heroku. It also makes setting up CI easier.

We will need to make some tweaks to have this support a different build for `production` but for now this should be fine for development.

I've updated the DEVELOPE.md as well.